### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/app/__mocks__/paper.json
+++ b/app/__mocks__/paper.json
@@ -49,7 +49,7 @@
       "url":
         "https://www.scholars.northwestern.edu/en/publications/preparation-and-characterization-of-graphene-oxide-paper"
     },
-    { "id": 0, "paperId": 0, "url": "http://dx.doi.org/10.1038/nature06016" },
+    { "id": 0, "paperId": 0, "url": "https://doi.org/10.1038/nature06016" },
     { "id": 0, "paperId": 0, "url": "http://adsabs.harvard.edu/abs/2007Natur.448..457D" },
     {
       "id": 0,

--- a/app/components/articleSearch/components/searchItem/doiButton.tsx
+++ b/app/components/articleSearch/components/searchItem/doiButton.tsx
@@ -11,7 +11,7 @@ interface DOIButtonProps {
 }
 
 function copyDOI(DOI: string) {
-  copySelectedTextToClipboard(`https://dx.doi.org/${DOI}`);
+  copySelectedTextToClipboard(`https://doi.org/${DOI}`);
 }
 
 const DOIButton = ({ DOI, style }: DOIButtonProps) => {

--- a/app/components/articleSearch/components/searchItem/index.tsx
+++ b/app/components/articleSearch/components/searchItem/index.tsx
@@ -107,7 +107,7 @@ class SearchItem extends React.PureComponent<
 
     let source: string;
     if (!!doi) {
-      source = `https://dx.doi.org/${doi}`;
+      source = `https://doi.org/${doi}`;
     } else if (urls && urls.length > 0) {
       source = urls[0].url;
     } else {

--- a/app/components/articleSearch/components/searchItem/infoList.tsx
+++ b/app/components/articleSearch/components/searchItem/infoList.tsx
@@ -37,7 +37,7 @@ class InfoList extends React.PureComponent<InfoListProps, {}> {
 
     let source: string;
     if (!!paper.doi) {
-      source = `https://dx.doi.org/${paper.doi}`;
+      source = `https://doi.org/${paper.doi}`;
     } else if (paper.urls && paper.urls.length > 0) {
       source = paper.urls[0].url;
     } else {

--- a/app/components/common/paperItemV2/index.tsx
+++ b/app/components/common/paperItemV2/index.tsx
@@ -88,7 +88,7 @@ class PaperItemV2 extends React.PureComponent<PaperItemV2Props, {}> {
 
     let source: string;
     if (paper && paper.doi) {
-      source = `https://dx.doi.org/${paper.doi}`;
+      source = `https://doi.org/${paper.doi}`;
     } else if (paper.urls && paper.urls.length > 0) {
       source = paper.urls[0].url;
     } else {

--- a/app/components/paperShow/components/referencePaperItem.tsx
+++ b/app/components/paperShow/components/referencePaperItem.tsx
@@ -91,7 +91,7 @@ class ReferenceItem extends React.PureComponent<ReferenceItemProps, {}> {
 
     let source: string;
     if (paper.doi) {
-      source = `https://dx.doi.org/${paper.doi}`;
+      source = `https://doi.org/${paper.doi}`;
     } else if (paper.urls && paper.urls.length > 0) {
       source = paper.urls[0].url;
     } else {
@@ -154,7 +154,7 @@ class ReferenceItem extends React.PureComponent<ReferenceItemProps, {}> {
   private clickDOIButton = () => {
     const { paper } = this.props;
 
-    copySelectedTextToClipboard(`https://dx.doi.org/${paper.doi}`);
+    copySelectedTextToClipboard(`https://doi.org/${paper.doi}`);
     trackEvent({ category: "paper-show", action: "copy-DOI", label: paper.id.toString() });
   };
 

--- a/app/components/paperShow/index.tsx
+++ b/app/components/paperShow/index.tsx
@@ -725,7 +725,7 @@ class PaperShow extends React.PureComponent<PaperShowProps, PaperShowStates> {
     const { paper } = this.props;
 
     if (paper) {
-      copySelectedTextToClipboard(`https://dx.doi.org/${paper.doi}`);
+      copySelectedTextToClipboard(`https://doi.org/${paper.doi}`);
       trackEvent({
         category: "paper-show",
         action: "copy-DOI",
@@ -778,7 +778,7 @@ class PaperShow extends React.PureComponent<PaperShowProps, PaperShowStates> {
     } else {
       let source: string;
       if (paper.doi) {
-        source = `https://dx.doi.org/${paper.doi}`;
+        source = `https://doi.org/${paper.doi}`;
       } else if (paper.urls && paper.urls[0]) {
         source = paper.urls[0].url;
       } else {


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update any code that generates new DOI links.

Cheers!